### PR TITLE
partialord + ord for nodeid

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 #![warn(
     missing_docs,
     missing_debug_implementations,
-    missing_copy_implementations
+    missing_copy_implementations,
 )]
 
 use std::fmt::{self, Debug, Formatter};
@@ -117,14 +117,12 @@ pub struct NodeMut<'a, T: 'a> {
 
 // Trait implementations regardless of T.
 
-impl<'a, T: 'a> Copy for NodeRef<'a, T> {}
+impl<'a, T: 'a> Copy for NodeRef<'a, T> { }
 impl<'a, T: 'a> Clone for NodeRef<'a, T> {
-    fn clone(&self) -> Self {
-        *self
-    }
+    fn clone(&self) -> Self { *self }
 }
 
-impl<'a, T: 'a> Eq for NodeRef<'a, T> {}
+impl<'a, T: 'a> Eq for NodeRef<'a, T> { }
 impl<'a, T: 'a> PartialEq for NodeRef<'a, T> {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
@@ -136,9 +134,7 @@ impl<'a, T: 'a> PartialEq for NodeRef<'a, T> {
 impl<T> Tree<T> {
     /// Creates a tree with a root node.
     pub fn new(root: T) -> Self {
-        Tree {
-            vec: vec![Node::new(root)],
-        }
+        Tree { vec: vec![Node::new(root)] }
     }
 
     /// Creates a tree with a root node and the specified capacity.
@@ -150,11 +146,7 @@ impl<T> Tree<T> {
 
     /// Returns a reference to the specified node.
     pub fn get(&self, id: NodeId) -> Option<NodeRef<T>> {
-        self.vec.get(id.to_index()).map(|node| NodeRef {
-            id,
-            node,
-            tree: self,
-        })
+        self.vec.get(id.to_index()).map(|node| NodeRef { id, node, tree: self })
     }
 
     /// Returns a mutator of the specified node.
@@ -173,11 +165,7 @@ impl<T> Tree<T> {
 
     /// Returns a reference to the specified node.
     pub unsafe fn get_unchecked(&self, id: NodeId) -> NodeRef<T> {
-        NodeRef {
-            id,
-            node: self.node(id),
-            tree: self,
-        }
+        NodeRef { id, node: self.node(id), tree: self }
     }
 
     /// Returns a mutator of the specified node.
@@ -221,37 +209,27 @@ impl<'a, T: 'a> NodeRef<'a, T> {
 
     /// Returns the parent of this node.
     pub fn parent(&self) -> Option<Self> {
-        self.node
-            .parent
-            .map(|id| unsafe { self.tree.get_unchecked(id) })
+        self.node.parent.map(|id| unsafe { self.tree.get_unchecked(id) })
     }
 
     /// Returns the previous sibling of this node.
     pub fn prev_sibling(&self) -> Option<Self> {
-        self.node
-            .prev_sibling
-            .map(|id| unsafe { self.tree.get_unchecked(id) })
+        self.node.prev_sibling.map(|id| unsafe { self.tree.get_unchecked(id) })
     }
 
     /// Returns the next sibling of this node.
     pub fn next_sibling(&self) -> Option<Self> {
-        self.node
-            .next_sibling
-            .map(|id| unsafe { self.tree.get_unchecked(id) })
+        self.node.next_sibling.map(|id| unsafe { self.tree.get_unchecked(id) })
     }
 
     /// Returns the first child of this node.
     pub fn first_child(&self) -> Option<Self> {
-        self.node
-            .children
-            .map(|(id, _)| unsafe { self.tree.get_unchecked(id) })
+        self.node.children.map(|(id, _)| unsafe { self.tree.get_unchecked(id) })
     }
 
     /// Returns the last child of this node.
     pub fn last_child(&self) -> Option<Self> {
-        self.node
-            .children
-            .map(|(_, id)| unsafe { self.tree.get_unchecked(id) })
+        self.node.children.map(|(_, id)| unsafe { self.tree.get_unchecked(id) })
     }
 
     /// Returns true if this node has siblings.
@@ -373,14 +351,10 @@ impl<'a, T: 'a> NodeMut<'a, T> {
         }
 
         if let Some(id) = prev_sibling_id {
-            unsafe {
-                self.tree.node_mut(id).next_sibling = next_sibling_id;
-            }
+            unsafe { self.tree.node_mut(id).next_sibling = next_sibling_id; }
         }
         if let Some(id) = next_sibling_id {
-            unsafe {
-                self.tree.node_mut(id).prev_sibling = prev_sibling_id;
-            }
+            unsafe { self.tree.node_mut(id).prev_sibling = prev_sibling_id; }
         }
 
         let parent = unsafe { self.tree.node_mut(parent_id) };
@@ -409,9 +383,7 @@ impl<'a, T: 'a> NodeMut<'a, T> {
         }
 
         if let Some(id) = last_child_id {
-            unsafe {
-                self.tree.node_mut(id).next_sibling = Some(new_child_id);
-            }
+            unsafe { self.tree.node_mut(id).next_sibling = Some(new_child_id); }
         }
 
         {
@@ -440,9 +412,7 @@ impl<'a, T: 'a> NodeMut<'a, T> {
         }
 
         if let Some(id) = first_child_id {
-            unsafe {
-                self.tree.node_mut(id).prev_sibling = Some(new_child_id);
-            }
+            unsafe { self.tree.node_mut(id).prev_sibling = Some(new_child_id); }
         }
 
         {
@@ -474,9 +444,7 @@ impl<'a, T: 'a> NodeMut<'a, T> {
         }
 
         if let Some(id) = prev_sibling_id {
-            unsafe {
-                self.tree.node_mut(id).next_sibling = Some(new_sibling_id);
-            }
+            unsafe { self.tree.node_mut(id).next_sibling = Some(new_sibling_id); }
         }
 
         self.node().prev_sibling = Some(new_sibling_id);
@@ -510,9 +478,7 @@ impl<'a, T: 'a> NodeMut<'a, T> {
         }
 
         if let Some(id) = next_sibling_id {
-            unsafe {
-                self.tree.node_mut(id).prev_sibling = Some(new_sibling_id);
-            }
+            unsafe { self.tree.node_mut(id).prev_sibling = Some(new_sibling_id); }
         }
 
         self.node().next_sibling = Some(new_sibling_id);
@@ -689,21 +655,21 @@ impl<T: Debug> Debug for Tree<T> {
                 match edge {
                     Edge::Open(node) if node.has_children() => {
                         write!(f, " {:?} => {{", node.value())?;
-                    }
+                    },
                     Edge::Open(node) if node.next_sibling().is_some() => {
                         write!(f, " {:?},", node.value())?;
-                    }
+                    },
                     Edge::Open(node) => {
                         write!(f, " {:?}", node.value())?;
-                    }
+                    },
                     Edge::Close(node) if node.has_children() => {
                         if node.next_sibling().is_some() {
                             write!(f, " }},")?;
                         } else {
                             write!(f, " }}")?;
                         }
-                    }
-                    _ => {}
+                    },
+                    _ => {},
                 }
             }
             write!(f, " }}")


### PR DESCRIPTION
As node-ids are simply integers, it's useful to be able to compare two ids to see which one appears first in the tree