### PR TITLE
Provide consuming movement methods so that NodeMut can act as a cursor.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,39 +247,36 @@ impl<'a, T: 'a> NodeRef<'a, T> {
         &self.node.value
     }
 
+    fn axis<F>(&self, f: F) -> Option<Self>
+    where
+        F: FnOnce(&Node<T>) -> Option<NodeId>,
+    {
+        f(self.node).map(|id| unsafe { self.tree.get_unchecked(id) })
+    }
+
     /// Returns the parent of this node.
     pub fn parent(&self) -> Option<Self> {
-        self.node
-            .parent
-            .map(|id| unsafe { self.tree.get_unchecked(id) })
+        self.axis(|node| node.parent)
     }
 
     /// Returns the previous sibling of this node.
     pub fn prev_sibling(&self) -> Option<Self> {
-        self.node
-            .prev_sibling
-            .map(|id| unsafe { self.tree.get_unchecked(id) })
+        self.axis(|node| node.prev_sibling)
     }
 
     /// Returns the next sibling of this node.
     pub fn next_sibling(&self) -> Option<Self> {
-        self.node
-            .next_sibling
-            .map(|id| unsafe { self.tree.get_unchecked(id) })
+        self.axis(|node| node.next_sibling)
     }
 
     /// Returns the first child of this node.
     pub fn first_child(&self) -> Option<Self> {
-        self.node
-            .children
-            .map(|(id, _)| unsafe { self.tree.get_unchecked(id) })
+        self.axis(|node| node.children.map(|(id, _)| id))
     }
 
     /// Returns the last child of this node.
     pub fn last_child(&self) -> Option<Self> {
-        self.node
-            .children
-            .map(|(_, id)| unsafe { self.tree.get_unchecked(id) })
+        self.axis(|node| node.children.map(|(_, id)| id))
     }
 
     /// Returns true if this node has siblings.
@@ -313,34 +310,70 @@ impl<'a, T: 'a> NodeMut<'a, T> {
         &mut self.node().value
     }
 
+    fn axis<F>(&mut self, f: F) -> Option<NodeMut<T>>
+    where
+        F: FnOnce(&mut Node<T>) -> Option<NodeId>,
+    {
+        let id = f(self.node());
+        id.map(move |id| unsafe { self.tree.get_unchecked_mut(id) })
+    }
+
+    fn into_axis<F>(mut self, f: F) -> Option<Self>
+    where
+        F: FnOnce(&mut Node<T>) -> Option<NodeId>,
+    {
+        let id = f(self.node());
+        id.map(move |id| unsafe { self.tree.get_unchecked_mut(id) })
+    }
+
     /// Returns the parent of this node.
     pub fn parent(&mut self) -> Option<NodeMut<T>> {
-        let id = self.node().parent;
-        id.map(move |id| unsafe { self.tree.get_unchecked_mut(id) })
+        self.axis(|node| node.parent)
+    }
+
+    /// Returns the parent of this node.
+    pub fn into_parent(self) -> Option<Self> {
+        self.into_axis(|node| node.parent)
     }
 
     /// Returns the previous sibling of this node.
     pub fn prev_sibling(&mut self) -> Option<NodeMut<T>> {
-        let id = self.node().prev_sibling;
-        id.map(move |id| unsafe { self.tree.get_unchecked_mut(id) })
+        self.axis(|node| node.prev_sibling)
+    }
+
+    /// Returns the previous sibling of this node.
+    pub fn into_prev_sibling(self) -> Option<Self> {
+        self.into_axis(|node| node.prev_sibling)
     }
 
     /// Returns the next sibling of this node.
     pub fn next_sibling(&mut self) -> Option<NodeMut<T>> {
-        let id = self.node().next_sibling;
-        id.map(move |id| unsafe { self.tree.get_unchecked_mut(id) })
+        self.axis(|node| node.next_sibling)
+    }
+
+    /// Returns the next sibling of this node.
+    pub fn into_next_sibling(self) -> Option<Self> {
+        self.into_axis(|node| node.next_sibling)
     }
 
     /// Returns the first child of this node.
     pub fn first_child(&mut self) -> Option<NodeMut<T>> {
-        let ids = self.node().children;
-        ids.map(move |(id, _)| unsafe { self.tree.get_unchecked_mut(id) })
+        self.axis(|node| node.children.map(|(id, _)| id))
+    }
+
+    /// Returns the first child of this node.
+    pub fn into_first_child(self) -> Option<Self> {
+        self.into_axis(|node| node.children.map(|(id, _)| id))
     }
 
     /// Returns the last child of this node.
     pub fn last_child(&mut self) -> Option<NodeMut<T>> {
-        let ids = self.node().children;
-        ids.map(move |(_, id)| unsafe { self.tree.get_unchecked_mut(id) })
+        self.axis(|node| node.children.map(|(_, id)| id))
+    }
+
+    /// Returns the last child of this node.
+    pub fn into_last_child(self) -> Option<Self> {
+        self.into_axis(|node| node.children.map(|(_, id)| id))
     }
 
     /// Returns true if this node has siblings.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,12 +318,15 @@ impl<'a, T: 'a> NodeMut<'a, T> {
         id.map(move |id| unsafe { self.tree.get_unchecked_mut(id) })
     }
 
-    fn into_axis<F>(mut self, f: F) -> Option<Self>
+    fn into_axis<F>(mut self, f: F) -> Result<Self, Self>
     where
         F: FnOnce(&mut Node<T>) -> Option<NodeId>,
     {
         let id = f(self.node());
-        id.map(move |id| unsafe { self.tree.get_unchecked_mut(id) })
+        match id {
+            Some(id) => Ok(unsafe { self.tree.get_unchecked_mut(id) }),
+            None => Err(self),
+        }
     }
 
     /// Returns the parent of this node.
@@ -332,7 +335,10 @@ impl<'a, T: 'a> NodeMut<'a, T> {
     }
 
     /// Returns the parent of this node.
-    pub fn into_parent(self) -> Option<Self> {
+    ///
+    /// Returns `Ok(parent)` if possible and `Err(self)` otherwise
+    /// so the caller can recover the current position.
+    pub fn into_parent(self) -> Result<Self, Self> {
         self.into_axis(|node| node.parent)
     }
 
@@ -342,7 +348,10 @@ impl<'a, T: 'a> NodeMut<'a, T> {
     }
 
     /// Returns the previous sibling of this node.
-    pub fn into_prev_sibling(self) -> Option<Self> {
+    ///
+    /// Returns `Ok(prev_sibling)` if possible and `Err(self)` otherwise
+    /// so the caller can recover the current position.
+    pub fn into_prev_sibling(self) -> Result<Self, Self> {
         self.into_axis(|node| node.prev_sibling)
     }
 
@@ -352,7 +361,10 @@ impl<'a, T: 'a> NodeMut<'a, T> {
     }
 
     /// Returns the next sibling of this node.
-    pub fn into_next_sibling(self) -> Option<Self> {
+    ///
+    /// Returns `Ok(next_sibling)` if possible and `Err(self)` otherwise
+    /// so the caller can recover the current position.
+    pub fn into_next_sibling(self) -> Result<Self, Self> {
         self.into_axis(|node| node.next_sibling)
     }
 
@@ -362,7 +374,10 @@ impl<'a, T: 'a> NodeMut<'a, T> {
     }
 
     /// Returns the first child of this node.
-    pub fn into_first_child(self) -> Option<Self> {
+    ///
+    /// Returns `Ok(first_child)` if possible and `Err(self)` otherwise
+    /// so the caller can recover the current position.
+    pub fn into_first_child(self) -> Result<Self, Self> {
         self.into_axis(|node| node.children.map(|(id, _)| id))
     }
 
@@ -372,7 +387,10 @@ impl<'a, T: 'a> NodeMut<'a, T> {
     }
 
     /// Returns the last child of this node.
-    pub fn into_last_child(self) -> Option<Self> {
+    ///
+    /// Returns `Ok(last_child)` if possible and `Err(self)` otherwise
+    /// so the caller can recover the current position.
+    pub fn into_last_child(self) -> Result<Self, Self> {
         self.into_axis(|node| node.children.map(|(_, id)| id))
     }
 

--- a/tests/node_mut.rs
+++ b/tests/node_mut.rs
@@ -278,6 +278,30 @@ fn insert_after() {
 }
 
 #[test]
+fn insert_at_index() {
+    let mut tree = tree!('a' => { 'b', 'c', 'e' });
+
+    {
+        let mut root = tree.root_mut();
+        let mut child = root.first_child().unwrap();
+
+        for _ in 0..2 {
+            child = child.into_next_sibling().unwrap();
+        }
+
+        child.insert_before('d');
+    }
+
+    let descendants = tree
+        .root()
+        .descendants()
+        .map(|n| n.value())
+        .collect::<Vec<_>>();
+
+    assert_eq!(&[&'a', &'b', &'c', &'d', &'e',], &descendants[..]);
+}
+
+#[test]
 fn detach() {
     let mut tree = tree!('a' => { 'b', 'd' });
     let mut root = tree.root_mut();


### PR DESCRIPTION
~~Still a draft because I added only the `into_next_sibling` method instead of handling all axes until we agreed that this is a helpful approach.~~ Added the missing methods after trying out a bit deduplication of internals.