### PR TITLE
Implement serde traits for ego-tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 .vscode
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,13 @@ authors = [
 license = "ISC"
 repository = "https://github.com/rust-scraper/ego-tree"
 readme = "README.md"
+
+[features]
+serde = ["dep:serde"]
+
+[dependencies]
+serde = { version = "1.0.209" , optional = true }
+
+[dev-dependencies]
+serde = "1.0.209"
+serde_json = "1.0.127"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ serde = { version = "1.0.209", optional = true }
 [dev-dependencies]
 serde = "1.0.209"
 serde_json = "1.0.127"
+serde_test = "1.0.177"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 serde = ["dep:serde"]
 
 [dependencies]
-serde = { version = "1.0.209" , optional = true }
+serde = { version = "1.0.209", optional = true }
 
 [dev-dependencies]
 serde = "1.0.209"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,4 @@ serde = { version = "1.0.209", optional = true }
 
 [dev-dependencies]
 serde = "1.0.209"
-serde_json = "1.0.127"
 serde_test = "1.0.177"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,10 @@
 use std::fmt::{self, Debug, Display, Formatter};
 use std::num::NonZeroUsize;
 
+#[cfg(feature = "serde")]
+/// Implement serde traits for Tree
+pub mod serde;
+
 /// Vec-backed ID-tree.
 ///
 /// Always contains at least a root node.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,21 @@
 use std::fmt::{self, Debug, Display, Formatter};
 use std::num::NonZeroUsize;
 
-#[cfg(feature = "serde")]
 /// Implement serde traits for Tree
+///
+/// ```
+/// use ego_tree::{tree, Tree};
+///
+/// let tree = tree!("a" => {"b", "c" => {"d", "e"}, "f"});
+/// let repr = serde_json::to_string(&tree).unwrap();
+/// let re_tree: Tree<&str> = serde_json::from_str(&repr).unwrap();
+/// ```
+///
+///
+/// # Warning
+/// Serialize and Deserialize implementations are recursive. They require an amount of stack memory
+/// propotional to the tree depth.
+#[cfg(feature = "serde")]
 pub mod serde;
 
 /// Vec-backed ID-tree.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,11 +38,6 @@
 use std::fmt::{self, Debug, Display, Formatter};
 use std::num::NonZeroUsize;
 
-/// Implement serde::Serialize and serde::Deserialize traits for Tree
-///
-/// # Warning
-/// Serialize and Deserialize implementations are recursive. They require an amount of stack memory
-/// proportional to the tree depth.
 #[cfg(feature = "serde")]
 pub mod serde;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,20 +38,11 @@
 use std::fmt::{self, Debug, Display, Formatter};
 use std::num::NonZeroUsize;
 
-/// Implement serde traits for Tree
-///
-/// ```
-/// use ego_tree::{tree, Tree};
-///
-/// let tree = tree!("a" => {"b", "c" => {"d", "e"}, "f"});
-/// let repr = serde_json::to_string(&tree).unwrap();
-/// let re_tree: Tree<&str> = serde_json::from_str(&repr).unwrap();
-/// ```
-///
+/// Implement serde::Serialize and serde::Deserialize traits for Tree
 ///
 /// # Warning
 /// Serialize and Deserialize implementations are recursive. They require an amount of stack memory
-/// propotional to the tree depth.
+/// proportional to the tree depth.
 #[cfg(feature = "serde")]
 pub mod serde;
 
@@ -72,7 +63,7 @@ pub struct NodeId(NonZeroUsize);
 impl NodeId {
     // Safety: `n` must not equal `usize::MAX`.
     // (This is never the case for `Vec::len()`, that would mean it owns
-    // the entire address space without leaving space for even the its pointer.)
+    // the entire address space without leaving space even for its pointer.)
     unsafe fn from_index(n: usize) -> Self {
         NodeId(NonZeroUsize::new_unchecked(n + 1))
     }
@@ -92,7 +83,7 @@ struct Node<T> {
 }
 
 fn _static_assert_size_of_node() {
-    // "Instanciating" the generic `transmute` function without calling it
+    // "Instantiating" the generic `transmute` function without calling it
     // still triggers the magic compile-time check
     // that input and output types have the same `size_of()`.
     let _ = std::mem::transmute::<Node<()>, [usize; 5]>;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -41,12 +41,12 @@ struct DeserNode<T> {
 }
 
 impl<T> DeserNode<T> {
-    fn to_tree_node(self, tree: &mut Tree<T>, parent: NodeId) -> NodeId {
+    fn into_tree_node(self, tree: &mut Tree<T>, parent: NodeId) -> NodeId {
         let mut parent = tree.get_mut(parent).unwrap();
         let node = parent.append(self.value).id();
 
         for child in self.children {
-            child.to_tree_node(tree, node);
+            child.into_tree_node(tree, node);
         }
 
         node
@@ -59,7 +59,7 @@ impl<T> From<DeserNode<T>> for Tree<T> {
         let root_id = tree.root().id;
 
         for child in root.children {
-            child.to_tree_node(&mut tree, root_id);
+            child.into_tree_node(&mut tree, root_id);
         }
 
         tree

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,3 +1,9 @@
+//! Implement `serde::Serialize` and `serde::Deserialize` traits for Tree
+//!
+//! # Warning
+//! Serialize and Deserialize implementations are recursive. They require an amount of stack memory
+//! proportional to the depth of the tree.
+
 use std::{fmt, marker::PhantomData};
 
 use serde::{

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,83 @@
+#![cfg(feature = "serde")]
+use std::num::NonZeroUsize;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{Node, NodeId, Tree};
+
+impl<T: Serialize> Serialize for Tree<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.vec.serialize(serializer)
+    }
+}
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for Tree<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = Vec::deserialize(deserializer)?;
+        Ok(Tree { vec })
+    }
+}
+
+impl<T: Serialize> Serialize for Node<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        (
+            &self.parent,
+            &self.prev_sibling,
+            &self.next_sibling,
+            &self.children,
+            &self.value,
+        )
+            .serialize(serializer)
+    }
+}
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for Node<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let (parent, prev_sibling, next_sibling, children, value) =
+            <(
+                Option<NodeId>,
+                Option<NodeId>,
+                Option<NodeId>,
+                Option<(NodeId, NodeId)>,
+                T,
+            )>::deserialize(deserializer)?;
+        Ok(Node {
+            parent,
+            prev_sibling,
+            next_sibling,
+            children,
+            value,
+        })
+    }
+}
+
+impl Serialize for NodeId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for NodeId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let index = <NonZeroUsize>::deserialize(deserializer)?;
+        Ok(NodeId(index))
+    }
+}

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -16,9 +16,9 @@ struct SerNode<'a, T> {
 
 impl<'a, T> From<NodeRef<'a, T>> for SerNode<'a, T> {
     fn from(node: NodeRef<'a, T>) -> Self {
-        let value: &T = node.value();
-        let children: Vec<SerNode<'a, T>> = node.children().map(SerNode::<'a, T>::from).collect();
-        SerNode { value, children }
+        let value = node.value();
+        let children = node.children().map(SerNode::from).collect();
+        Self { value, children }
     }
 }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -12,7 +12,7 @@ use serde::{
     Deserialize, Deserializer,
 };
 
-use crate::{NodeId, NodeMut, NodeRef, Tree};
+use crate::{NodeMut, NodeRef, Tree};
 
 #[derive(Debug)]
 struct SerNode<'a, T> {
@@ -56,14 +56,12 @@ struct DeserNode<T> {
 }
 
 impl<T> DeserNode<T> {
-    fn into_tree_node(self, parent: &mut NodeMut<T>) -> NodeId {
+    fn into_tree_node(self, parent: &mut NodeMut<T>) {
         let mut node = parent.append(self.value);
 
         for child in self.children {
             child.into_tree_node(&mut node);
         }
-
-        node.id
     }
 }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -27,7 +27,7 @@ impl<'a, T: Serialize> Serialize for SerNode<'a, T> {
     where
         S: serde::Serializer,
     {
-        let mut state = serializer.serialize_struct("SerNode", 2)?;
+        let mut state = serializer.serialize_struct("Node", 2)?;
         state.serialize_field("value", &self.value)?;
         state.serialize_field("children", &self.children)?;
         state.end()
@@ -93,7 +93,7 @@ where
     type Value = DeserNode<T>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("struct DeserNode")
+        formatter.write_str("struct Node")
     }
 
     fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
@@ -138,11 +138,7 @@ where
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_struct(
-            "DeserNode",
-            &["value", "children"],
-            DeserNodeVisitor::new(),
-        )
+        deserializer.deserialize_struct("Node", &["value", "children"], DeserNodeVisitor::new())
     }
 }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "serde")]
 use std::num::NonZeroUsize;
 
 use serde::{Deserialize, Serialize};

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate ego_tree;
+use ego_tree::tree;
 
 #[test]
 fn into_iter() {

--- a/tests/macro.rs
+++ b/tests/macro.rs
@@ -1,7 +1,4 @@
-#[macro_use]
-extern crate ego_tree;
-
-use ego_tree::Tree;
+use ego_tree::{tree, Tree};
 
 #[test]
 fn root() {

--- a/tests/node_mut.rs
+++ b/tests/node_mut.rs
@@ -1,7 +1,4 @@
-#[macro_use]
-extern crate ego_tree;
-
-use ego_tree::NodeRef;
+use ego_tree::{tree, NodeRef};
 
 #[test]
 fn value() {

--- a/tests/node_ref.rs
+++ b/tests/node_ref.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate ego_tree;
+use ego_tree::tree;
 
 #[test]
 fn value() {

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,16 @@
+#![cfg(feature = "serde")]
+#[macro_use]
+extern crate ego_tree;
+use std::assert_eq;
+
+use ego_tree::Tree;
+
+#[test]
+fn test_serialize() {
+    let tree = tree!("r" => {"a", "b" => { "d", "e" }, "c"});
+
+    let serialized = serde_json::to_string(&tree).unwrap();
+    let deserialized: Tree<&str> = serde_json::from_str(&serialized).unwrap();
+
+    assert_eq!(tree, deserialized);
+}

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "serde")]
 
 use ego_tree::{tree, Tree};
+use serde_test::{assert_tokens, Token};
 
 #[test]
 fn test_serde_round_trip() {
@@ -10,4 +11,25 @@ fn test_serde_round_trip() {
     let re_tree: Tree<&str> = serde_json::from_str(&repr).unwrap();
     println!("{re_tree}");
     assert_eq!(tree, re_tree);
+}
+
+#[test]
+fn test_internal_serde_repr() {
+    let tree = tree!("a");
+
+    assert_tokens(
+        &tree,
+        &[
+            Token::Struct {
+                name: "Node",
+                len: 2,
+            },
+            Token::Str("value"),
+            Token::Str("a"),
+            Token::Str("children"),
+            Token::Seq { len: Some(0) },
+            Token::SeqEnd,
+            Token::StructEnd,
+        ],
+    );
 }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -3,9 +3,11 @@
 use ego_tree::{tree, Tree};
 
 #[test]
-fn test_serialize() {
-    let tree = tree!("r" => {"a", "b" => { "d", "e" }, "c"});
-
-    let serialized = serde_json::to_string(&tree).unwrap();
-    println!("{serialized}");
+fn test_serde_round_trip() {
+    let tree = tree!("a" => {"b", "c" => {"d", "e"}, "f"});
+    let repr = serde_json::to_string(&tree).unwrap();
+    println!("{repr}");
+    let re_tree: Tree<&str> = serde_json::from_str(&repr).unwrap();
+    println!("{re_tree}");
+    assert_eq!(tree, re_tree);
 }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -8,7 +8,4 @@ fn test_serialize() {
 
     let serialized = serde_json::to_string(&tree).unwrap();
     println!("{serialized}");
-    let deserialized: Tree<&str> = serde_json::from_str(&serialized).unwrap();
-
-    assert_eq!(tree, deserialized);
 }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,7 +1,5 @@
 #![cfg(feature = "serde")]
 
-use std::assert_eq;
-
 use ego_tree::{tree, Tree};
 
 #[test]

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,15 +1,15 @@
 #![cfg(feature = "serde")]
-#[macro_use]
-extern crate ego_tree;
+
 use std::assert_eq;
 
-use ego_tree::Tree;
+use ego_tree::{tree, Tree};
 
 #[test]
 fn test_serialize() {
     let tree = tree!("r" => {"a", "b" => { "d", "e" }, "c"});
 
     let serialized = serde_json::to_string(&tree).unwrap();
+    println!("{serialized}");
     let deserialized: Tree<&str> = serde_json::from_str(&serialized).unwrap();
 
     assert_eq!(tree, deserialized);

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,20 +1,10 @@
 #![cfg(feature = "serde")]
 
-use ego_tree::{tree, Tree};
+use ego_tree::tree;
 use serde_test::{assert_tokens, Token};
 
 #[test]
-fn test_serde_round_trip() {
-    let tree = tree!("a" => {"b", "c" => {"d", "e"}, "f"});
-    let repr = serde_json::to_string(&tree).unwrap();
-    println!("{repr}");
-    let re_tree: Tree<&str> = serde_json::from_str(&repr).unwrap();
-    println!("{re_tree}");
-    assert_eq!(tree, re_tree);
-}
-
-#[test]
-fn test_internal_serde_repr() {
+fn test_internal_serde_repr_trivial() {
     let tree = tree!("a");
 
     assert_tokens(
@@ -24,10 +14,81 @@ fn test_internal_serde_repr() {
                 name: "Node",
                 len: 2,
             },
-            Token::Str("value"),
-            Token::Str("a"),
-            Token::Str("children"),
+            Token::BorrowedStr("value"),
+            Token::BorrowedStr("a"),
+            Token::BorrowedStr("children"),
             Token::Seq { len: Some(0) },
+            Token::SeqEnd,
+            Token::StructEnd,
+        ],
+    );
+}
+
+#[test]
+fn test_internal_serde_repr() {
+    let tree = tree!("a" => {"b", "c" => {"d", "e"}, "f"});
+
+    assert_tokens(
+        &tree,
+        &[
+            Token::Struct {
+                name: "Node",
+                len: 2,
+            },
+            Token::BorrowedStr("value"),
+            Token::BorrowedStr("a"),
+            Token::BorrowedStr("children"),
+            Token::Seq { len: Some(3) },
+            Token::Struct {
+                name: "Node",
+                len: 2,
+            },
+            Token::BorrowedStr("value"),
+            Token::BorrowedStr("b"),
+            Token::BorrowedStr("children"),
+            Token::Seq { len: Some(0) },
+            Token::SeqEnd,
+            Token::StructEnd,
+            Token::Struct {
+                name: "Node",
+                len: 2,
+            },
+            Token::BorrowedStr("value"),
+            Token::BorrowedStr("c"),
+            Token::BorrowedStr("children"),
+            Token::Seq { len: Some(2) },
+            Token::Struct {
+                name: "Node",
+                len: 2,
+            },
+            Token::BorrowedStr("value"),
+            Token::BorrowedStr("d"),
+            Token::BorrowedStr("children"),
+            Token::Seq { len: Some(0) },
+            Token::SeqEnd,
+            Token::StructEnd,
+            Token::Struct {
+                name: "Node",
+                len: 2,
+            },
+            Token::BorrowedStr("value"),
+            Token::BorrowedStr("e"),
+            Token::BorrowedStr("children"),
+            Token::Seq { len: Some(0) },
+            Token::SeqEnd,
+            Token::StructEnd,
+            Token::SeqEnd,
+            Token::StructEnd,
+            Token::Struct {
+                name: "Node",
+                len: 2,
+            },
+            Token::BorrowedStr("value"),
+            Token::BorrowedStr("f"),
+            Token::BorrowedStr("children"),
+            Token::Seq { len: Some(0) },
+            Token::SeqEnd,
+            Token::StructEnd,
             Token::SeqEnd,
             Token::StructEnd,
         ],

--- a/tests/subtree.rs
+++ b/tests/subtree.rs
@@ -1,39 +1,35 @@
-#[macro_use]
-extern crate ego_tree;
+use ego_tree::tree;
 
-#[cfg(test)]
-mod test {
-    #[test]
-    fn prepend_subtree() {
-        let mut tree = tree!('a' => { 'b', 'c' => { 'd', 'e' } });
-        let node_id = tree.root().first_child().unwrap().id();
-        let mut node = tree.get_mut(node_id).unwrap();
-        assert_eq!(node.value(), &'b');
+#[test]
+fn prepend_subtree() {
+    let mut tree = tree!('a' => { 'b', 'c' => { 'd', 'e' } });
+    let node_id = tree.root().first_child().unwrap().id();
+    let mut node = tree.get_mut(node_id).unwrap();
+    assert_eq!(node.value(), &'b');
 
-        let subtree = tree!('f' => { 'g', 'h' => { 'i', 'j' } });
-        let mut root_subtree = node.prepend_subtree(subtree);
-        assert_eq!(root_subtree.parent().unwrap().value(), &'b');
-        assert_eq!(
-            root_subtree.parent().unwrap().parent().unwrap().value(),
-            &'a'
-        );
+    let subtree = tree!('f' => { 'g', 'h' => { 'i', 'j' } });
+    let mut root_subtree = node.prepend_subtree(subtree);
+    assert_eq!(root_subtree.parent().unwrap().value(), &'b');
+    assert_eq!(
+        root_subtree.parent().unwrap().parent().unwrap().value(),
+        &'a'
+    );
 
-        let new_tree =
-            tree!('a' => { 'b' => { 'f' => { 'g', 'h' => { 'i', 'j' } } }, 'c' => { 'd', 'e' } });
-        assert_eq!(format!("{:#?}", tree), format!("{:#?}", new_tree));
-    }
+    let new_tree =
+        tree!('a' => { 'b' => { 'f' => { 'g', 'h' => { 'i', 'j' } } }, 'c' => { 'd', 'e' } });
+    assert_eq!(format!("{:#?}", tree), format!("{:#?}", new_tree));
+}
 
-    #[test]
-    fn append_subtree() {
-        let mut tree = tree!('a' => { 'b', 'c' });
-        let mut node = tree.root_mut();
-        assert_eq!(node.value(), &'a');
+#[test]
+fn append_subtree() {
+    let mut tree = tree!('a' => { 'b', 'c' });
+    let mut node = tree.root_mut();
+    assert_eq!(node.value(), &'a');
 
-        let subtree = tree!('d' => { 'e', 'f' });
-        let mut root_subtree = node.append_subtree(subtree);
-        assert_eq!(root_subtree.parent().unwrap().value(), &'a');
+    let subtree = tree!('d' => { 'e', 'f' });
+    let mut root_subtree = node.append_subtree(subtree);
+    assert_eq!(root_subtree.parent().unwrap().value(), &'a');
 
-        let new_tree = tree!('a' => { 'b', 'c', 'd' => { 'e', 'f' } });
-        assert_eq!(format!("{:#?}", tree), format!("{:#?}", new_tree));
-    }
+    let new_tree = tree!('a' => { 'b', 'c', 'd' => { 'e', 'f' } });
+    assert_eq!(format!("{:#?}", tree), format!("{:#?}", new_tree));
 }

--- a/tests/tree.rs
+++ b/tests/tree.rs
@@ -1,5 +1,3 @@
-extern crate ego_tree;
-
 use ego_tree::{tree, Tree};
 
 #[test]


### PR DESCRIPTION
Solves https://github.com/rust-scraper/ego-tree/issues/21

I encapsulated everything inside the `serde` module. I implemented manually `Serialize` and `Deseriaize` for
- `Tree<T>`
- `Node<T>`
- `NodeId`

Needs a review focused on security, and maybe more tests.