### PR TITLE
Add `fn map_values(…)` method to `Tree<T>`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,16 @@ impl<T> Node<T> {
             value,
         }
     }
+
+    fn map_value<U>(self, transform: impl FnOnce(T) -> U) -> Node<U> {
+        Node {
+            parent: self.parent,
+            prev_sibling: self.prev_sibling,
+            next_sibling: self.next_sibling,
+            children: self.children,
+            value: transform(self.value),
+        }
+    }
 }
 
 /// Node reference.
@@ -231,6 +241,18 @@ impl<T> Tree<T> {
         }
         self.vec.extend(other_tree.vec);
         unsafe { self.get_unchecked_mut(other_tree_root_id) }
+    }
+
+    /// Maps a `Tree<T>` to `Tree<U>` by applying a function to all node values,
+    /// without modifying the nodes' ids, or the tree's structure.
+    pub fn map_values<U>(self, transform: impl Fn(T) -> U) -> Tree<U> {
+        Tree {
+            vec: self
+                .vec
+                .into_iter()
+                .map(|node| node.map_value(&transform))
+                .collect(),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,10 @@ impl<T> Node<T> {
         }
     }
 
-    fn map<U>(self, mut transform: impl FnMut(T) -> U) -> Node<U> {
+    pub fn map<F, U>(self, mut transform: F) -> Node<U>
+    where
+        F: FnMut(T) -> U,
+    {
         Node {
             parent: self.parent,
             prev_sibling: self.prev_sibling,
@@ -105,7 +108,10 @@ impl<T> Node<T> {
         }
     }
 
-    fn map_ref<U>(&self, mut transform: impl FnMut(&T) -> U) -> Node<U> {
+    pub fn map_ref<F, U>(&self, mut transform: F) -> Node<U>
+    where
+        F: FnMut(&T) -> U,
+    {
         Node {
             parent: self.parent,
             prev_sibling: self.prev_sibling,
@@ -255,7 +261,10 @@ impl<T> Tree<T> {
 
     /// Maps a `Tree<T>` to `Tree<U>` by applying a function to all node values,
     /// copying over the tree's structure and node ids untouched, consuming `self`.
-    pub fn map<U>(self, mut transform: impl FnMut(T) -> U) -> Tree<U> {
+    pub fn map<F, U>(self, mut transform: F) -> Tree<U>
+    where
+        F: FnMut(T) -> U,
+    {
         Tree {
             vec: self
                 .vec
@@ -267,7 +276,10 @@ impl<T> Tree<T> {
 
     /// Maps a `&Tree<T>` to `Tree<U>` by applying a function to all node values,
     /// copying over the tree's structure and node ids untouched.
-    pub fn map_ref<U>(&self, mut transform: impl FnMut(&T) -> U) -> Tree<U> {
+    pub fn map_ref<F, U>(&self, mut transform: F) -> Tree<U>
+    where
+        F: FnMut(&T) -> U,
+    {
         Tree {
             vec: self
                 .vec

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,16 @@ impl<T> Node<T> {
             value: transform(self.value),
         }
     }
+
+    fn map_value_ref<U>(&self, transform: impl FnOnce(&T) -> U) -> Node<U> {
+        Node {
+            parent: self.parent,
+            prev_sibling: self.prev_sibling,
+            next_sibling: self.next_sibling,
+            children: self.children,
+            value: transform(&self.value),
+        }
+    }
 }
 
 /// Node reference.
@@ -244,13 +254,25 @@ impl<T> Tree<T> {
     }
 
     /// Maps a `Tree<T>` to `Tree<U>` by applying a function to all node values,
-    /// without modifying the nodes' ids, or the tree's structure.
+    /// copying over the tree's structure and node ids untouched, consuming `self`.
     pub fn map_values<U>(self, transform: impl Fn(T) -> U) -> Tree<U> {
         Tree {
             vec: self
                 .vec
                 .into_iter()
                 .map(|node| node.map_value(&transform))
+                .collect(),
+        }
+    }
+
+    /// Maps a `&Tree<T>` to `Tree<U>` by applying a function to all node values,
+    /// copying over the tree's structure and node ids untouched.
+    pub fn map_value_refs<U>(&self, transform: impl Fn(&T) -> U) -> Tree<U> {
+        Tree {
+            vec: self
+                .vec
+                .iter()
+                .map(|node| node.map_value_ref(&transform))
                 .collect(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ impl<T> Node<T> {
         }
     }
 
-    fn map_value<U>(self, mut transform: impl FnMut(T) -> U) -> Node<U> {
+    fn map<U>(self, mut transform: impl FnMut(T) -> U) -> Node<U> {
         Node {
             parent: self.parent,
             prev_sibling: self.prev_sibling,
@@ -105,7 +105,7 @@ impl<T> Node<T> {
         }
     }
 
-    fn map_value_ref<U>(&self, mut transform: impl FnMut(&T) -> U) -> Node<U> {
+    fn map_ref<U>(&self, mut transform: impl FnMut(&T) -> U) -> Node<U> {
         Node {
             parent: self.parent,
             prev_sibling: self.prev_sibling,
@@ -255,24 +255,24 @@ impl<T> Tree<T> {
 
     /// Maps a `Tree<T>` to `Tree<U>` by applying a function to all node values,
     /// copying over the tree's structure and node ids untouched, consuming `self`.
-    pub fn map_values<U>(self, mut transform: impl FnMut(T) -> U) -> Tree<U> {
+    pub fn map<U>(self, mut transform: impl FnMut(T) -> U) -> Tree<U> {
         Tree {
             vec: self
                 .vec
                 .into_iter()
-                .map(|node| node.map_value(&mut transform))
+                .map(|node| node.map(&mut transform))
                 .collect(),
         }
     }
 
     /// Maps a `&Tree<T>` to `Tree<U>` by applying a function to all node values,
     /// copying over the tree's structure and node ids untouched.
-    pub fn map_value_refs<U>(&self, mut transform: impl FnMut(&T) -> U) -> Tree<U> {
+    pub fn map_ref<U>(&self, mut transform: impl FnMut(&T) -> U) -> Tree<U> {
         Tree {
             vec: self
                 .vec
                 .iter()
-                .map(|node| node.map_value_ref(&mut transform))
+                .map(|node| node.map_ref(&mut transform))
                 .collect(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ impl<T> Node<T> {
         }
     }
 
-    fn map_value<U>(self, transform: impl FnOnce(T) -> U) -> Node<U> {
+    fn map_value<U>(self, mut transform: impl FnMut(T) -> U) -> Node<U> {
         Node {
             parent: self.parent,
             prev_sibling: self.prev_sibling,
@@ -105,7 +105,7 @@ impl<T> Node<T> {
         }
     }
 
-    fn map_value_ref<U>(&self, transform: impl FnOnce(&T) -> U) -> Node<U> {
+    fn map_value_ref<U>(&self, mut transform: impl FnMut(&T) -> U) -> Node<U> {
         Node {
             parent: self.parent,
             prev_sibling: self.prev_sibling,
@@ -255,24 +255,24 @@ impl<T> Tree<T> {
 
     /// Maps a `Tree<T>` to `Tree<U>` by applying a function to all node values,
     /// copying over the tree's structure and node ids untouched, consuming `self`.
-    pub fn map_values<U>(self, transform: impl Fn(T) -> U) -> Tree<U> {
+    pub fn map_values<U>(self, mut transform: impl FnMut(T) -> U) -> Tree<U> {
         Tree {
             vec: self
                 .vec
                 .into_iter()
-                .map(|node| node.map_value(&transform))
+                .map(|node| node.map_value(&mut transform))
                 .collect(),
         }
     }
 
     /// Maps a `&Tree<T>` to `Tree<U>` by applying a function to all node values,
     /// copying over the tree's structure and node ids untouched.
-    pub fn map_value_refs<U>(&self, transform: impl Fn(&T) -> U) -> Tree<U> {
+    pub fn map_value_refs<U>(&self, mut transform: impl FnMut(&T) -> U) -> Tree<U> {
         Tree {
             vec: self
                 .vec
                 .iter()
-                .map(|node| node.map_value_ref(&transform))
+                .map(|node| node.map_value_ref(&mut transform))
                 .collect(),
         }
     }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -28,7 +28,7 @@ impl<'a, T> From<NodeRef<'a, T>> for SerNode<'a, T> {
     }
 }
 
-impl<'a, T: Serialize> Serialize for SerNode<'a, T> {
+impl<T: Serialize> Serialize for SerNode<'_, T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/tests/tree.rs
+++ b/tests/tree.rs
@@ -168,13 +168,13 @@ fn test_map_values() {
         }
     };
 
-    let identity_mapped_tree = str_tree.clone().map_values(|value| value);
+    let identity_mapped_tree = str_tree.clone().map(|value| value);
 
     // If we pass the identity function to `.map_values()`,
     // then we expect the tree to effectively remain untouched:
     assert_eq!(str_tree, identity_mapped_tree);
 
-    let string_tree = str_tree.clone().map_values(|value| value.to_owned());
+    let string_tree = str_tree.clone().map(|value| value.to_owned());
 
     // A `&str` will produce the same output for `.to_string()` as its equivalent `String`,
     // so the output of `.to_string()` should match for corresponding trees as well:
@@ -194,13 +194,13 @@ fn test_map_value_refs() {
         }
     };
 
-    let identity_mapped_tree = str_tree.map_value_refs(|&value| value);
+    let identity_mapped_tree = str_tree.map_ref(|&value| value);
 
     // If we pass the identity function to `.map_values()`,
     // then we expect the tree to effectively remain untouched:
     assert_eq!(str_tree, identity_mapped_tree);
 
-    let string_tree = str_tree.map_value_refs(|&value| value.to_owned());
+    let string_tree = str_tree.map_ref(|&value| value.to_owned());
 
     // A `&str` will produce the same output for `.to_string()` as its equivalent `String`,
     // so the output of `.to_string()` should match for corresponding trees as well:

--- a/tests/tree.rs
+++ b/tests/tree.rs
@@ -182,6 +182,32 @@ fn test_map_values() {
 }
 
 #[test]
+fn test_map_value_refs() {
+    let str_tree = tree! {
+        "root" => {
+            "a" => {
+                "child 1",
+            },
+            "b" => {
+                "child 2",
+            },
+        }
+    };
+
+    let identity_mapped_tree = str_tree.map_value_refs(|&value| value);
+
+    // If we pass the identity function to `.map_values()`,
+    // then we expect the tree to effectively remain untouched:
+    assert_eq!(str_tree, identity_mapped_tree);
+
+    let string_tree = str_tree.map_value_refs(|&value| value.to_owned());
+
+    // A `&str` will produce the same output for `.to_string()` as its equivalent `String`,
+    // so the output of `.to_string()` should match for corresponding trees as well:
+    assert_eq!(str_tree.to_string(), string_tree.to_string());
+}
+
+#[test]
 fn test_display() {
     let tree = tree! {
         "root" => {

--- a/tests/tree.rs
+++ b/tests/tree.rs
@@ -156,6 +156,32 @@ fn insert_id_before() {
 }
 
 #[test]
+fn test_map_values() {
+    let str_tree = tree! {
+        "root" => {
+            "a" => {
+                "child 1",
+            },
+            "b" => {
+                "child 2",
+            },
+        }
+    };
+
+    let identity_mapped_tree = str_tree.clone().map_values(|value| value);
+
+    // If we pass the identity function to `.map_values()`,
+    // then we expect the tree to effectively remain untouched:
+    assert_eq!(str_tree, identity_mapped_tree);
+
+    let string_tree = str_tree.clone().map_values(|value| value.to_owned());
+
+    // A `&str` will produce the same output for `.to_string()` as its equivalent `String`,
+    // so the output of `.to_string()` should match for corresponding trees as well:
+    assert_eq!(str_tree.to_string(), string_tree.to_string());
+}
+
+#[test]
 fn test_display() {
     let tree = tree! {
         "root" => {


### PR DESCRIPTION
I needed to map trees from one node value type to another and implementing such a mapping via the existing public API was _sub-optimal_, while with access to the internals it turned out to be trivial.