### PR TITLE
Replace uses of std with core and alloc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,17 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets --all-features -- --deny warnings
 
+  build-no-std:
+    name: Cargo build (no_std)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+            targets: thumbv7m-none-eabi
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --all-features --target thumbv7m-none-eabi
+
   test:
     name: Test code
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "ego-tree"
 edition = "2024"
 version = "0.11.0"
 description = "Vec-backed ID-tree"
-categories = ["data-structures"]
+categories = ["data-structures", "no-std"]
 keywords = ["tree", "vec", "id", "index"]
 authors = [
     "June McEnroe <june@causal.agency>",
@@ -14,11 +14,11 @@ repository = "https://github.com/rust-scraper/ego-tree"
 readme = "README.md"
 
 [features]
-serde = ["dep:serde"]
+serde = ["dep:serde_core"]
 
 [dependencies]
-serde = { version = "1.0.209", optional = true }
+serde_core = { version = "1.0.209", default-features = false, features = ["alloc"], optional = true }
 
 [dev-dependencies]
-serde = "1.0.209"
+serde_core = "1.0.209"
 serde_test = "1.0.177"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![downloads](https://img.shields.io/crates/d/ego-tree)][crate]
 [![test](https://github.com/rust-scraper/ego-tree/actions/workflows/test.yml/badge.svg)][tests]
 
-`ego-tree` is a Rust crate that provides a Vec-backed ID-tree implementation. It offers a flexible and efficient way to create and manipulate tree structures in Rust, with a focus on performance and ease of use.
+`ego-tree` is a Rust crate that provides a Vec-backed ID-tree implementation. It offers a flexible and efficient way to create and manipulate tree structures in Rust, with a focus on performance and ease of use. Usable in `no_std` contexts (requires `alloc`).
 
 `ego-tree` is on [Crates.io][crate] and [GitHub][github].
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,4 +1,5 @@
-use std::fmt::Display;
+use alloc::vec::Vec;
+use core::fmt::Display;
 
 /// Indentation token
 #[derive(Debug)]
@@ -10,7 +11,7 @@ struct Token {
 }
 
 impl Display for Token {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         let Token { siblings, children } = self;
 
         write!(
@@ -49,7 +50,7 @@ pub struct Indentation {
 }
 
 impl Display for Indentation {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         let first: usize = if self.ignore_root { 1 } else { 0 };
 
         for token in &self.tokens[first..] {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,6 +1,7 @@
-use std::iter::FusedIterator;
-use std::ops::Range;
-use std::{slice, vec};
+use alloc::vec;
+use core::iter::FusedIterator;
+use core::ops::Range;
+use core::slice;
 
 use crate::{Node, NodeId, NodeRef, Tree};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,9 +34,13 @@
     missing_debug_implementations,
     missing_copy_implementations
 )]
+#![no_std]
 
-use std::fmt::{self, Debug, Display, Formatter};
-use std::num::NonZeroUsize;
+use alloc::vec::Vec;
+use core::fmt::{self, Debug, Display, Formatter};
+use core::num::NonZeroUsize;
+
+extern crate alloc;
 
 #[cfg(feature = "serde")]
 pub mod serde;
@@ -81,7 +85,7 @@ fn _static_assert_size_of_node() {
     // "Instantiating" the generic `transmute` function without calling it
     // still triggers the magic compile-time check
     // that input and output types have the same `size_of()`.
-    let _ = std::mem::transmute::<Node<()>, [usize; 5]>;
+    let _ = core::mem::transmute::<Node<()>, [usize; 5]>;
 }
 
 impl<T> Node<T> {
@@ -157,8 +161,8 @@ impl<'a, T: 'a> Eq for NodeRef<'a, T> {}
 impl<'a, T: 'a> PartialEq for NodeRef<'a, T> {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
-            && std::ptr::eq(self.tree, other.tree)
-            && std::ptr::eq(self.node, other.node)
+            && core::ptr::eq(self.tree, other.tree)
+            && core::ptr::eq(self.node, other.node)
     }
 }
 
@@ -166,7 +170,7 @@ impl<T> Tree<T> {
     /// Creates a tree with a root node.
     pub fn new(root: T) -> Self {
         Tree {
-            vec: vec![Node::new(root)],
+            vec: alloc::vec![Node::new(root)],
         }
     }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,14 +1,14 @@
-//! Implement `serde::Serialize` and `serde::Deserialize` traits for Tree
+//! Implement `serde_core::Serialize` and `serde_core::Deserialize` traits for Tree
 //!
 //! # Warning
 //! Serialize and Deserialize implementations are recursive. They require an amount of stack memory
 //! proportional to the depth of the tree.
 
-use std::{fmt, marker::PhantomData};
+use alloc::vec::Vec;
+use core::{fmt, marker::PhantomData};
 
-use serde::{
-    Deserialize, Deserializer,
-    de::{self, MapAccess, Visitor},
+use serde_core::{
+    de::{self, Deserialize, MapAccess, Visitor},
     ser::{Serialize, SerializeStruct},
 };
 
@@ -31,7 +31,7 @@ impl<'a, T> From<NodeRef<'a, T>> for SerNode<'a, T> {
 impl<T: Serialize> Serialize for SerNode<'_, T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
         let mut state = serializer.serialize_struct("Node", 2)?;
         state.serialize_field("value", &self.value)?;
@@ -43,7 +43,7 @@ impl<T: Serialize> Serialize for SerNode<'_, T> {
 impl<T: Serialize> Serialize for Tree<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: serde_core::Serializer,
     {
         SerNode::from(self.root()).serialize(serializer)
     }
@@ -140,7 +140,7 @@ where
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
         deserializer.deserialize_struct("Node", &["value", "children"], DeserNodeVisitor::new())
     }
@@ -149,7 +149,7 @@ where
 impl<'de, T: Deserialize<'de>> Deserialize<'de> for Tree<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: serde_core::Deserializer<'de>,
     {
         let deser = DeserNode::<T>::deserialize(deserializer)?;
         Ok(deser.into())

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -3,7 +3,8 @@
 //! This module provides methods for sorting children of a node in a tree.
 //! The sorting can be done based on the node values or their indices.
 
-use std::cmp::Ordering;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
 
 use crate::{NodeMut, NodeRef};
 


### PR DESCRIPTION
Kia ora!

Just a small PR to allow using this crate in `no_std` contexts!

There aren't any uses of `std` beyond structures already exposed in `alloc`, so it's a pretty trivial patch.

I've mainly changed import `use`s, but also a couple of fully qualified paths where they exist. I also added `no-std` as a keyword/category in `Cargo.toml` and the README to advertise this feature a bit more as it can be hard to tell at a glance if a crate uses `std` or not. Let me know if you'd prefer any changes to my approach, happy to tweak things :)

Thanks for the great crate!